### PR TITLE
Refactor and make migrate dynamodb glue to IoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@
     * [x] update ECS Service's Number of tasks to 0
     * [x] docker stop container
   * [x] dynamodb
-    * [x] export to s3
-    * [x] use glue data pipeline to recover db in new account
+    * [x] create DynamoDBCrossAccessRole in old account and add new account in trust entity
+    * [x] use glue job to migrate db from old account to new account
   * [x] migrate redis db
   * [x] DNS change
   * [x] update [ptt-alertor](https://github.com/Ptt-Alertor/ptt-alertor) task definition

--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -1,0 +1,18 @@
+# DynamoDB
+
+
+## Mirgrate from old account to new account
+
+```sh
+aws cloudformation deploy --stack-name Glue --template-file glue.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides OldAccountId=${OldAccountId}
+```
+
+```sh
+aws glue start-job-run --job-name migrate-dynamodb --arguments='--table_name="articles"'
+```
+
+```sh
+aws glue start-job-run --job-name migrate-dynamodb --arguments='--table_name="boards"'
+```

--- a/dynamodb/glue.yaml
+++ b/dynamodb/glue.yaml
@@ -1,0 +1,65 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Glue Migrate DynamoDB
+
+Parameters:
+  OldAccountId:
+    Type: String
+
+Resources:
+  ## Create in Old Account
+  # DynamoDBCrossAccessRole:
+  #   Type: AWS::IAM::Role
+  #   Properties:
+  #     RoleName: DynamoDBCrossAccessRole
+  #     AssumeRolePolicyDocument:
+  #       Version: "2012-10-17"
+  #       Statement:
+  #         - Effect: Allow
+  #           Principal:
+  #             AWS: "arn:aws:iam::${NewAccountId}:root"
+  #           Action: sts:AssumeRole
+  #     Path: "/"
+  #     ManagedPolicyArns:
+  #       - arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
+
+  GlueMigrateDynamoDBRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "glue.amazonaws.com"
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AssumeDynamoDBCrossAccessRole
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Sub arn:aws:iam::${OldAccountId}:role/DynamoDBCrossAccessRole
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+
+  GlueMigrateTableJob:
+    Type: AWS::Glue::Job
+    Properties:
+      Name: migrate-dynamodb
+      GlueVersion: 3.0
+      Command:
+        Name: glueetl
+        PythonVersion: 3
+        ScriptLocation: !Sub
+          - s3://${S3}/glue/migrate_dynamodb.py
+          - S3: !ImportValue Ptt-Alertor-S3-Bucket-Name
+      DefaultArguments:
+        "--job-bookmark-option": "job-bookmark-enable"
+        "--table_name": ""
+        "--role_arn": !Sub arn:aws:iam::${OldAccountId}:role/DynamoDBCrossAccessRole
+      Role: !Ref GlueMigrateDynamoDBRole
+      MaxCapacity: 2

--- a/dynamodb/glue_import_ddb_from_s3.py
+++ b/dynamodb/glue_import_ddb_from_s3.py
@@ -1,0 +1,85 @@
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME'])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Script generated for node Amazon S3
+source = glueContext.create_dynamic_frame.from_options(
+    format_options={},
+    connection_type="s3",
+    format="parquet",
+    connection_options={
+        "paths": ["s3://aws-glue-assets-702626449187-us-west-2/run-DataSink0-1-part-block-0-r-00000-snappy.parquet"],
+        "recurse": False},
+    transformation_ctx="source"
+)
+
+# {
+#     "Item": {
+#         "Code": {
+#             "S": "M.1621834854.A.84E"
+#         },
+#         "Title": {
+#             "S": "[閒聊] 加密貨幣行情閒聊區-牛熊僅有一線之隔"
+#         },
+#         "Date": {
+#             "S": ""
+#         },
+#         "Comments": {
+#             "S": "[{\"Tag\":\"→ \",\"UserID\":\"illidan9999\",\"Content\":\": 已開新串\",\"DateTime\":\"2021-05-27T14:39:00+08:00\"}]"
+#         },
+#         "Author": {
+#             "S": ""
+#         },
+#         "LastPushDateTime": {
+#             "S": "2021-05-27T14:39:00+08:00"
+#         },
+#         "Link": {
+#             "S": "https://www.ptt.cc/bbs/DigiCurrency/M.1621834854.A.84E.html"
+#         },
+#         "ID": {
+#             "N": "1621834854"
+#         },
+#         "Board": {
+#             "S": "DigiCurrency"
+#         },
+#         "PushSum": {
+#             "N": "0"
+#         }
+#     }
+# }
+
+mapped = ApplyMapping.apply(frame=source, mappings=[
+    ("item.Code.S", "string", "Code", "string"),
+    ("item.Title.S", "string", "Title", "string"),
+    ("item.Date.S", "string", "Date", "string"),
+    ("item.Comments.S", "string", "Comments", "string"),
+    ("item.Author.S", "string", "Author", "string"),
+    ("item.LastPushDateTime.S", "string", "LastPushDateTime", "string"),
+    ("item.Link.S", "string", "Link", "string"),
+    ("item.ID.N", "integer", "ID", "integer"),
+    ("item.Board.S", "string", "Board", "string"),
+    ("item.PushSum.N", "integer", "PushSum", "integer")],
+    transformation_ctx="mapped")
+
+mapped.show()
+
+glueContext.write_dynamic_frame_from_options(
+    frame=mapped,
+    connection_type="dynamodb",
+    connection_options={
+        "dynamodb.output.tableName": "articles",
+        "dynamodb.throughput.write.percent": "1.0"
+    }
+)
+
+job.commit()

--- a/dynamodb/migrate_dynamodb.py
+++ b/dynamodb/migrate_dynamodb.py
@@ -4,8 +4,16 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.utils import getResolvedOptions
 
-args = getResolvedOptions(sys.argv, ["JOB_NAME"])
-glue_context= GlueContext(SparkContext.getOrCreate())
+args = getResolvedOptions(sys.argv, [
+    "JOB_NAME",
+    "table_name",
+    "role_arn"
+])
+table_name = args["table_name"]
+role_arn = args["role_arn"]
+
+
+glue_context = GlueContext(SparkContext.getOrCreate())
 job = Job(glue_context)
 job.init(args["JOB_NAME"], args)
 
@@ -13,8 +21,8 @@ dyf = glue_context.create_dynamic_frame_from_options(
     connection_type="dynamodb",
     connection_options={
         "dynamodb.region": "us-west-2",
-        "dynamodb.input.tableName": "boards",
-        "dynamodb.sts.roleArn": "arn:aws:iam::351400046513:role/DynamoCrossAccount"
+        "dynamodb.input.tableName": table_name,
+        "dynamodb.sts.roleArn": role_arn
     }
 )
 dyf.show()
@@ -23,8 +31,8 @@ glue_context.write_dynamic_frame_from_options(
     frame=dyf,
     connection_type="dynamodb",
     connection_options={
-        "dynamodb.output.tableName": "boards",
-        "dynamodb.throughput.write.percent": "1.0"
+        "dynamodb.output.tableName": table_name,
+        "dynamodb.throughput.write.percent": "0.5"
     }
 )
 job.commit()


### PR DESCRIPTION
## Reference

### Migrate from Table to Table
- <https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-dynamo-db-cross-account.html>
- <https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect.html#aws-glue-programming-etl-connect-dynamodb>
- <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html>
- <https://docs.aws.amazon.com/cli/latest/reference/glue/start-job-run.html>

### Migrate from Parquet
- <https://aws.amazon.com/tw/premiumsupport/knowledge-center/dynamodb-cross-account-migration/>
- <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataExport.html>
- <https://github.com/aws-samples/cross-account-amazon-dynamodb-replication/blob/main/InitialMigrationWithNativeExport/Import.py>
- <https://dev.to/lukaszbudnik/migrating-to-dynamodb-using-parquet-and-glue-21h9>
- <https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect.html#aws-glue-programming-etl-connect-s3>